### PR TITLE
chore: update release-please configuration to use 'rust' release type

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -2,7 +2,7 @@
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
-      "release-type": "simple",
+      "release-type": "rust",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          release-type: simple
+          release-type: rust


### PR DESCRIPTION
The change from `simple` to `rust` release type ensures that the release-please workflow is optimized for Rust projects. This aligns versioning and changelog generation with Rust-specific conventions, improving consistency and accuracy for releases in this ecosystem.